### PR TITLE
#89: Keeping the framework alive in subscribe methods, small improvements

### DIFF
--- a/src/integrationTest/java/org/tframework/test/properties/DefaultPropertyValueTest.java
+++ b/src/integrationTest/java/org/tframework/test/properties/DefaultPropertyValueTest.java
@@ -1,0 +1,28 @@
+/* Licensed under Apache-2.0 2024. */
+package org.tframework.test.properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.tframework.core.elements.annotations.InjectProperty;
+import org.tframework.test.junit5.IsolatedTFrameworkTest;
+
+@IsolatedTFrameworkTest
+public class DefaultPropertyValueTest {
+
+    @InjectProperty(value = "some.non.existing.property", defaultValue = "default")
+    private String stringProperty;
+
+    @InjectProperty(value = "some.non.existing.property", defaultValue = "123")
+    private int intProperty;
+
+    @Test
+    public void shouldInjectDefaultStringProperty() {
+        assertEquals("default", stringProperty);
+    }
+
+    @Test
+    public void shouldInjectDefaultIntProperty() {
+        assertEquals(123, intProperty);
+    }
+}

--- a/src/main/java/org/tframework/core/elements/annotations/ElementConstructor.java
+++ b/src/main/java/org/tframework/core/elements/annotations/ElementConstructor.java
@@ -11,7 +11,6 @@ import java.lang.annotation.Target;
  * This annotation marks a constructor as the one to be used when instantiating the element.
  * It is required only to when there are multiple constructors available, and the framework otherwise
  * wouldn't know which one to use.
- *
  * <pre>{@code
  * @Element
  * public class MyElement {

--- a/src/main/java/org/tframework/core/elements/annotations/InjectElement.java
+++ b/src/main/java/org/tframework/core/elements/annotations/InjectElement.java
@@ -16,7 +16,17 @@ import org.tframework.core.elements.ElementUtils;
  *     <li>Visibility can be any.</li>
  * </ul>
  * In all cases, when using {@link #value()} to specify an element by name, the element must be assignable
- * to the type of the field or parameter you are trying to inject it into.
+ * to the type of the field or parameter you are trying to inject it into. For example:
+ * <pre>{@code
+ * //assuming there is an element which is assignable to MyElement type
+ * @InjectElement
+ * private MyElement myElement;
+ *
+ * //assuming there is an element named 'my.element' which is assignable to MyElement type
+ * @InjectElement("my.element")
+ * private MyElement myElement;
+ * }</pre>
+ * These examples were for field injection, but the same applies to constructor injection.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/tframework/core/elements/annotations/InjectProperty.java
+++ b/src/main/java/org/tframework/core/elements/annotations/InjectProperty.java
@@ -16,15 +16,38 @@ import org.tframework.core.properties.converters.PropertyConverter;
  *     <li>Visibility can be any.</li>
  * </ul>
  * It is also required that an appropriate {@link PropertyConverter} exists that can convert the property
- * for the type of field or parameter.
+ * for the type of field or parameter. For example:
+ * <pre>{@code
+ * @InjectProperty("my.string.property")
+ * private String myStringProperty;
+ *
+ * //assuming 'my.int.property' can be converted to an int
+ * @InjectProperty("my.int.property")
+ * private int myIntProperty;
+ *
+ * //this will work even if the property is not found
+ * @InjectProperty(value = "my.boolean.property", defaultValue = "true")
+ * private boolean myBooleanProperty;
+ * }</pre>
+ * These examples were for field injection, but the same applies to constructor injection.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 public @interface InjectProperty {
 
+    String DEFAULT_VALUE_NOT_PROVIDED = "";
+
     /**
-     * The name of the property to inject.
+     * The <b>name</b> of the property to inject. Please note that despite this attribute being named
+     * {@code value}, it is actually the name of the property. It is named {@code value} because
+     * that is the default name for the attribute in annotations.
      */
     String value();
+
+    /**
+     * The default value to use if the property is not found.
+     * This is a raw string and will be converted to the appropriate type by the framework.
+     */
+    String defaultValue() default DEFAULT_VALUE_NOT_PROVIDED;
 
 }

--- a/src/main/java/org/tframework/core/elements/dependency/resolver/PropertyDependencyResolver.java
+++ b/src/main/java/org/tframework/core/elements/dependency/resolver/PropertyDependencyResolver.java
@@ -33,7 +33,19 @@ public class PropertyDependencyResolver implements BasicDependencyResolver {
             String dependencyName = injectAnnotation.value();
             log.debug("Attempting to resolve dependency with name '{}' from the properties...", dependencyName);
             try {
-                Object resolvedDependency = propertiesContainer.getPropertyValue(dependencyName, dependencyDefinition.dependencyType());
+                Object resolvedDependency;
+                if(injectAnnotation.defaultValue().equals(InjectProperty.DEFAULT_VALUE_NOT_PROVIDED)) {
+                    resolvedDependency = propertiesContainer.getPropertyValueNonGeneric(
+                            dependencyName,
+                            dependencyDefinition.dependencyType()
+                    );
+                } else {
+                    resolvedDependency = propertiesContainer.getPropertyValueNonGeneric(
+                            dependencyName,
+                            dependencyDefinition.dependencyType(),
+                            injectAnnotation.defaultValue()
+                    );
+                }
                 log.debug("Resolved dependency with name '{}' from the properties: {}", dependencyName, resolvedDependency);
                 return Optional.of(resolvedDependency);
             } catch (Exception e) {

--- a/src/main/java/org/tframework/core/events/publisher/AsyncMultithreadedEventPublisher.java
+++ b/src/main/java/org/tframework/core/events/publisher/AsyncMultithreadedEventPublisher.java
@@ -6,22 +6,29 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.tframework.core.elements.annotations.Element;
+import org.tframework.core.elements.annotations.InjectProperty;
 import org.tframework.core.events.Event;
 import org.tframework.core.events.Subscription;
 
 /**
- * This {@link EventPublisher} uses virtual threads to publish events asynchronously. It is
- * the recommended publisher, because virtual threads can scale well and this publisher does not
- * block the event management from handling other events.
+ * This {@link EventPublisher} uses several threads to publish events asynchronously. It is
+ * the recommended publisher, because it does not block the event management from handling other events.
+ * The {@value #EVENT_PUBLISHER_THREAD_POOL_SIZE_PROPERTY} property can be used to configure the number of threads
+ * used by this publisher. The default is 3.
  */
 @Slf4j
 @Element
-public class AsyncVirtualEventPublisher implements EventPublisher {
+public class AsyncMultithreadedEventPublisher implements EventPublisher {
+
+    public static final String EVENT_PUBLISHER_THREAD_POOL_SIZE_PROPERTY =
+            "org.tframework.core.events.thread-pool-size";
 
     private final ExecutorService executorService;
 
-    public AsyncVirtualEventPublisher() {
-        this.executorService = Executors.newVirtualThreadPerTaskExecutor();
+    public AsyncMultithreadedEventPublisher(
+            @InjectProperty(value = EVENT_PUBLISHER_THREAD_POOL_SIZE_PROPERTY, defaultValue = "3") int threadPoolSize
+    ) {
+        this.executorService = Executors.newFixedThreadPool(threadPoolSize);
     }
 
     @Override

--- a/src/main/java/org/tframework/core/properties/PropertiesContainer.java
+++ b/src/main/java/org/tframework/core/properties/PropertiesContainer.java
@@ -43,7 +43,7 @@ public final class PropertiesContainer {
     }
 
     /**
-     * Gets the {@link PropertyValue} of a property.
+     * Gets the {@link PropertyValue} of a property, without any conversion.
      * @return The {@link PropertyValue} for the given property name.
      * @throws PropertyNotFoundException If the property does not exist.
      */
@@ -52,7 +52,8 @@ public final class PropertiesContainer {
     }
 
     /**
-     * Gets the {@link PropertyValue} of a property, or the provided default one.
+     * Gets the {@link PropertyValue} of a property, or the provided default one,
+     * without any conversion.
      * @param propertyName The property to get.
      * @param defaultValue A default value to return if the property does not exist.
      */
@@ -78,6 +79,20 @@ public final class PropertiesContainer {
     }
 
     /**
+     * Gets a property by name, and converts it to the desired type. Returns the
+     * converted property as an {@link Object}. When it is more convenient, the
+     * {@link #getPropertyValue(String, Class)} is also available, which is generic.
+     * @param propertyName The property to get.
+     * @param requiredType The type to convert this property to.
+     * @throws PropertyNotFoundException If the property does not exist.
+     * @throws PropertyConversionException If the conversion failed to the required type.
+     */
+    public Object getPropertyValueNonGeneric(String propertyName, Class<?> requiredType) {
+        var propertyValueObject = getPropertyValueObject(propertyName);
+        return propertyConverterAggregator.convert(propertyValueObject, requiredType);
+    }
+
+    /**
      * A version of {@link #getPropertyValue(String, Class)} that returns a default value instead of throwing
      * {@link PropertyNotFoundException} when the given property does not exist.
      */
@@ -87,6 +102,25 @@ public final class PropertiesContainer {
         } catch (PropertyNotFoundException e) {
             log.debug("Property '{}' not found. Returning default value '{}'", propertyName, defaultValue);
             return defaultValue;
+        }
+    }
+
+    /**
+     * A version of {@link #getPropertyValueNonGeneric(String, Class)} that returns a default value instead of throwing
+     * {@link PropertyNotFoundException} when the given property does not exist. When it is more convenient, the
+     * {@link #getPropertyValue(String, Class, Object)} is also available, which is generic.
+     * @param propertyName The property to get.
+     * @param requiredType The type to convert this property to.
+     * @param defaultValue A {@link String} representation of the default value. It will be converted to
+     *                     the required type.
+     */
+    public Object getPropertyValueNonGeneric(String propertyName, Class<?> requiredType, String defaultValue) {
+        try {
+            return getPropertyValueNonGeneric(propertyName, requiredType);
+        } catch (PropertyNotFoundException e) {
+            log.debug("Property '{}' not found. Returning default value '{}'", propertyName, defaultValue);
+            var defaultPropertyValue = new SinglePropertyValue(defaultValue);
+            return propertyConverterAggregator.convert(defaultPropertyValue, requiredType);
         }
     }
 

--- a/src/test/java/org/tframework/core/events/publisher/AsyncMultithreadedEventPublisherTest.java
+++ b/src/test/java/org/tframework/core/events/publisher/AsyncMultithreadedEventPublisherTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.tframework.core.events.Event;
 import org.tframework.core.events.Subscription;
 
-public class AsyncVirtualEventPublisherTest {
+public class AsyncMultithreadedEventPublisherTest {
 
-    private final AsyncVirtualEventPublisher publisher = new AsyncVirtualEventPublisher();
+    private final AsyncMultithreadedEventPublisher publisher = new AsyncMultithreadedEventPublisher(1);
 
     private boolean published = false;
 

--- a/src/test/java/org/tframework/core/properties/PropertiesContainerTest.java
+++ b/src/test/java/org/tframework/core/properties/PropertiesContainerTest.java
@@ -33,7 +33,7 @@ class PropertiesContainerTest {
     }
 
     @Test
-    public void shouldGetPropertyValueObject_whenExists() {
+    public void shouldGetPropertyValue_Object_whenExists() {
         PropertyValue propertyValue = container.getPropertyValueObject("p1");
         if(propertyValue instanceof SinglePropertyValue(String value)) {
             assertEquals("v1", value);
@@ -55,7 +55,7 @@ class PropertiesContainerTest {
     }
 
     @Test
-    public void shouldGetPropertyValueObject_whenDoesNotExist_withDefaultValue() {
+    public void shouldGetPropertyValueObject_whenDoesNotExist_withDefaultValueObject() {
         PropertyValue propertyValue = container.getPropertyValueObject("p3", new SinglePropertyValue("default"));
         if(propertyValue instanceof SinglePropertyValue(String value)) {
             assertEquals("default", value);


### PR DESCRIPTION
Added default value to @InjectProperty annotation. Recreated default event publisher to use platform threads instead of virtual ones. Thread pool size is configurable. Added some more Javadoc.